### PR TITLE
Add cjermain as maintainer [no ci]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,3 +44,4 @@ extra:
   recipe-maintainers:
     - melund
     - ddale
+    - cjermain


### PR DESCRIPTION
This adds @cjermain as maintainer of the recipe. Shouldn't do anything else. [no ci]